### PR TITLE
oninput バインディング時のエラーを修正

### DIFF
--- a/QRCodeGenerator/Pages/Home.razor
+++ b/QRCodeGenerator/Pages/Home.razor
@@ -27,7 +27,7 @@
 
         <div class="col-12">
             <label class="form-label" for="BodyBox">内容</label>
-            <InputTextArea class="form-control" rows="3" id="BodyBox" @bind-Value="Body" @bind-Value:event="oninput" />
+            <textarea class="form-control" rows="3" id="BodyBox" @bind="Body" @bind:event="oninput"></textarea>
         </div>
 
         <div class="col-12">


### PR DESCRIPTION
## 概要
- 入力欄の `@bind-Value:event="oninput"` によるエラーを解消
- `<InputTextArea>` から `<textarea>` へ置き換え、`@bind:event="oninput"` を使用

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c52362c098832c8a15034f316fa8a5