### PR TITLE
QRコード表示をPC600px・スマホ400pxに調整

### DIFF
--- a/QRCodeGenerator/Layout/MainLayout.razor.css
+++ b/QRCodeGenerator/Layout/MainLayout.razor.css
@@ -1,7 +1,13 @@
 .page {
     padding: 1rem;
     width: 100%;
-    max-width: 300px;
+    max-width: 600px;
     margin-left: auto;
     margin-right: auto;
+}
+
+@media (max-width: 600px) {
+    .page {
+        max-width: 400px;
+    }
 }

--- a/QRCodeGenerator/Pages/Home.razor
+++ b/QRCodeGenerator/Pages/Home.razor
@@ -12,7 +12,7 @@
 <h1>QRCodeGenerator</h1>
 
 <div class="qr-container mt-3">
-    <div class="qr-preview">
+    <div class="qr-preview qr-preview-lg">
         <label class="form-label">プレビュー</label>
         <div class="qr-image border border-1 border-dark rounded rounded-2">
             <QRCodeSvg Level="@_model!.Level" Body="@_model!.Body" width="100%" height="100%" />
@@ -35,6 +35,13 @@
         <div>
             <label class="form-label" for="BodyBox">内容</label>
             <textarea class="form-control" rows="3" id="BodyBox" @bind="Body" @bind:event="oninput"></textarea>
+        </div>
+
+        <div class="qr-preview qr-preview-sm">
+            <label class="form-label">プレビュー</label>
+            <div class="qr-image border border-1 border-dark rounded rounded-2">
+                <QRCodeSvg Level="@_model!.Level" Body="@_model!.Body" width="100%" height="100%" />
+            </div>
         </div>
 
         <div>

--- a/QRCodeGenerator/Pages/Home.razor
+++ b/QRCodeGenerator/Pages/Home.razor
@@ -11,47 +11,36 @@
 
 <h1>QRCodeGenerator</h1>
 
-<div class="container-fluid mt-3">
-    <div class="row gy-3">
-        <div class="col-lg-6 d-none d-lg-block">
-            <label class="form-label">プレビュー</label>
-            <div class="ratio ratio-1x1 border border-1 border-dark rounded rounded-2">
-                <QRCodeSvg Level="@_model!.Level" Body="@_model!.Body" />
-            </div>
-        </div>
-
-        <div class="col-12 col-lg-6">
-            <EditForm class="row gy-3" Model="_model" OnValidSubmit="OnGenerateAsync">
-                <DataAnnotationsValidator />
-
-                <div class="col-12">
-                    <label class="form-label" for="ECCLevelBox">誤り訂正レベル</label>
-                    <InputSelect class="form-select" id="ECCLevelBox" TValue="QRCodeGenerator.ECCLevel" @bind-Value="_model!.Level">
-                        <option value="@QRCodeGenerator.ECCLevel.L">レベルL（7%）</option>
-                        <option value="@QRCodeGenerator.ECCLevel.M">レベルM（15%）</option>
-                        <option value="@QRCodeGenerator.ECCLevel.Q">レベルQ（25%）</option>
-                        <option value="@QRCodeGenerator.ECCLevel.H">レベルH（30%）</option>
-                    </InputSelect>
-                </div>
-
-                <div class="col-12">
-                    <label class="form-label" for="BodyBox">内容</label>
-                    <textarea class="form-control" rows="3" id="BodyBox" @bind="Body" @bind:event="oninput"></textarea>
-                </div>
-
-                <div class="col-12 d-lg-none">
-                    <label class="form-label">プレビュー</label>
-                    <div class="ratio ratio-1x1 border border-1 border-dark rounded rounded-2">
-                        <QRCodeSvg Level="@_model!.Level" Body="@_model!.Body" />
-                    </div>
-                </div>
-
-                <div class="col-12">
-                    <button class="btn btn-success w-100">保存</button>
-                </div>
-            </EditForm>
+<div class="qr-container mt-3">
+    <div class="qr-preview">
+        <label class="form-label">プレビュー</label>
+        <div class="qr-image border border-1 border-dark rounded rounded-2">
+            <QRCodeSvg Level="@_model!.Level" Body="@_model!.Body" width="100%" height="100%" />
         </div>
     </div>
+
+    <EditForm class="qr-form d-flex flex-column gap-3" Model="_model" OnValidSubmit="OnGenerateAsync">
+        <DataAnnotationsValidator />
+
+        <div>
+            <label class="form-label" for="ECCLevelBox">誤り訂正レベル</label>
+            <InputSelect class="form-select" id="ECCLevelBox" TValue="QRCodeGenerator.ECCLevel" @bind-Value="_model!.Level">
+                <option value="@QRCodeGenerator.ECCLevel.L">レベルL（7%）</option>
+                <option value="@QRCodeGenerator.ECCLevel.M">レベルM（15%）</option>
+                <option value="@QRCodeGenerator.ECCLevel.Q">レベルQ（25%）</option>
+                <option value="@QRCodeGenerator.ECCLevel.H">レベルH（30%）</option>
+            </InputSelect>
+        </div>
+
+        <div>
+            <label class="form-label" for="BodyBox">内容</label>
+            <textarea class="form-control" rows="3" id="BodyBox" @bind="Body" @bind:event="oninput"></textarea>
+        </div>
+
+        <div>
+            <button class="btn btn-success w-100">保存</button>
+        </div>
+    </EditForm>
 </div>
 
 @code {

--- a/QRCodeGenerator/wwwroot/css/app.css
+++ b/QRCodeGenerator/wwwroot/css/app.css
@@ -118,6 +118,11 @@ code {
     width: 400px;
 }
 
+.qr-preview-sm {
+    display: none;
+    margin: 0 auto;
+}
+
 @media (max-width: 600px) {
     .qr-container {
         width: 400px;
@@ -130,7 +135,11 @@ code {
         width: 100%;
     }
 
-    .qr-preview {
-        margin-bottom: 1rem;
+    .qr-preview-lg {
+        display: none;
+    }
+
+    .qr-preview-sm {
+        display: block;
     }
 }

--- a/QRCodeGenerator/wwwroot/css/app.css
+++ b/QRCodeGenerator/wwwroot/css/app.css
@@ -103,10 +103,11 @@ code {
     max-width: 100%;
     margin: 1rem auto 0 auto;
     display: flex;
+    gap: 1rem;
 }
 
 .qr-preview {
-    width: 200px;
+    flex: 0 0 200px;
 }
 
 .qr-image {
@@ -115,7 +116,8 @@ code {
 }
 
 .qr-form {
-    width: 400px;
+    flex: 1;
+    max-width: 400px;
 }
 
 .qr-preview-sm {
@@ -133,6 +135,7 @@ code {
 
     .qr-form {
         width: 100%;
+        max-width: none;
     }
 
     .qr-preview-lg {

--- a/QRCodeGenerator/wwwroot/css/app.css
+++ b/QRCodeGenerator/wwwroot/css/app.css
@@ -97,3 +97,40 @@ a, .btn-link {
 code {
     color: #c02d76;
 }
+
+.qr-container {
+    width: 600px;
+    max-width: 100%;
+    margin: 1rem auto 0 auto;
+    display: flex;
+}
+
+.qr-preview {
+    width: 200px;
+}
+
+.qr-image {
+    width: 200px;
+    height: 200px;
+}
+
+.qr-form {
+    width: 400px;
+}
+
+@media (max-width: 600px) {
+    .qr-container {
+        width: 400px;
+        max-width: 100%;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .qr-form {
+        width: 100%;
+    }
+
+    .qr-preview {
+        margin-bottom: 1rem;
+    }
+}


### PR DESCRIPTION
## 概要
- 画面幅が広い場合は横600pxで左200pxにプレビュー、右400pxに入力欄を配置
- 画面幅が狭い場合は縦400pxでQRコードを中央に表示

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68c5878e389c832c9697b5d5c01bf2cf